### PR TITLE
Fix login button redirect

### DIFF
--- a/packages/web/src/app/(landing)/page.tsx
+++ b/packages/web/src/app/(landing)/page.tsx
@@ -94,7 +94,13 @@ export default function Home() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 w-full md:w-auto">
                 <Button
-                  onClick={login}
+                  onClick={() => {
+                    if (authenticated) {
+                      router.push('/dashboard');
+                      return;
+                    }
+                    login();
+                  }}
                   className="bg-[#2663FF] text-white font-bold rounded-lg px-8 py-3 text-base shadow-sm border border-[#2663FF] hover:bg-[#1A4FDB] focus:ring-2 focus:ring-[#2663FF] focus:outline-none transition-all"
                   style={{ minWidth: 180 }}
                 >


### PR DESCRIPTION
## Summary
- send logged in users to dashboard when clicking **get started** on the landing page

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.4.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.4.tgz)*