### PR TITLE
Fix email onboarding state refresh

### DIFF
--- a/packages/web/src/app/onboarding/add-email/page.tsx
+++ b/packages/web/src/app/onboarding/add-email/page.tsx
@@ -17,9 +17,10 @@ export default function AddEmailPage() {
 
   const utils = api.useUtils();
   const updateEmail = api.user.updateEmail.useMutation({
-    onSuccess: () => {
-      // Invalidate cached profile so other components get fresh data
-      utils.user.getProfile.invalidate();
+    async onSuccess() {
+      // Invalidate cached profile and refetch so state stays fresh
+      await utils.user.getProfile.invalidate();
+      await utils.user.getProfile.fetch();
     },
   });
 

--- a/packages/web/src/app/onboarding/layout.tsx
+++ b/packages/web/src/app/onboarding/layout.tsx
@@ -68,14 +68,6 @@ export default function OnboardingLayout({
   });
 
   const hasEmail = !!(user?.email?.address || userProfile?.email);
-  useEffect(() => {
-    if (ready && authenticated) {
-      const hasEmail = !!user?.email?.address;
-      if (!hasEmail && pathname !== '/onboarding/add-email') {
-        router.replace('/onboarding/add-email');
-      }
-    }
-  }, [ready, authenticated, user, pathname, router]);
 
   const handleSignOut = async () => {
     try {


### PR DESCRIPTION
## Summary
- refresh user profile after updating email
- use updated profile data when redirecting during onboarding

## Testing
- `pnpm lint` *(fails: `turbo: not found`)*
- `pnpm -r test` *(fails: missing dependencies)*